### PR TITLE
Data attribute support

### DIFF
--- a/example/app/app.component.html
+++ b/example/app/app.component.html
@@ -5,9 +5,9 @@
     [disabledItemValues]="disabledItemValues"
     [activeItemValues]="activeItemValues"
     [items]="[
-      {icon: 'u-supre-icon u-supre-icon--refresh-clear', value: 'clear', class: '-toggle-action'},
-      {icon: 'u-supre-icon u-supre-icon--filter', value: 'filter', class: '-toggle-action'},
-      {icon: 'u-supre-icon u-supre-icon--arrow-down-filled', value: 'dataGrid', class: '-toggle-action background open-bottom'}
+      {icon: 'u-supre-icon u-supre-icon--refresh-clear', value: 'clear', class: '-toggle-action', data : {'qa-id' : 'clear'}},
+      {icon: 'u-supre-icon u-supre-icon--filter', value: 'filter', class: '-toggle-action', data : {'qa-id' : 'filter'}},
+      {icon: 'u-supre-icon u-supre-icon--arrow-down-filled', value: 'dataGrid', class: '-toggle-action background open-bottom', data : {'qa-id' : 'open'}}
     ]"
   ></supre-toggle>
   <hr>

--- a/src/data.directive.ts
+++ b/src/data.directive.ts
@@ -1,0 +1,37 @@
+import { Directive, Input, OnChanges, ElementRef } from '@angular/core';
+/*
+  Dynamically sets data attributes for an element from an object
+*/
+@Directive({
+  selector: '[supreData]'
+})
+export class DataDirective implements OnChanges {
+
+  @Input() supreData: any;
+
+  constructor(private el: ElementRef) { }
+
+
+  ngOnChanges(changes) {
+    const dataChanges = changes.supreData;
+    if (dataChanges) {
+      const prev = dataChanges.previousValue;
+      if (prev) {
+        for (const propName in prev) {
+          if (prev.hasOwnProperty(propName)) {
+            this.el.nativeElement.removeAttribute(`data-${propName}`);
+          }
+        }
+      }
+      const current = dataChanges.currentValue;
+      if (current) {
+        for (const propName in current) {
+          if (current.hasOwnProperty(propName)) {
+            this.el.nativeElement.setAttribute(`data-${propName}`, current[propName]);
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,24 @@
 import { CommonModule } from '@angular/common';
 import { ToggleComponent } from './toggle.component';
+import { DataDirective } from './data.directive';
 import { NgModule } from '@angular/core';
 
 export * from './toggle.component';
 
 @NgModule({
     imports: [
-        CommonModule,
+        CommonModule
     ],
     declarations: [
-        ToggleComponent,
+        DataDirective,
+        ToggleComponent
     ],
     exports: [
+        DataDirective,
         ToggleComponent,
     ],
     entryComponents: [
-        ToggleComponent,
+        ToggleComponent
     ]
 })
 export class ToggleModule {

--- a/src/toggle.component.html
+++ b/src/toggle.component.html
@@ -4,6 +4,7 @@
     (click)="onClick(item);"
     [disabled]="disabledItemValues === true || (disabledItemValues && disabledItemValues.indexOf(item.value) > -1)"
     [class]="item.class || '-toggle'"
+    [supreData]="item.data"
     [ngClass]="{
       'is-active': (activeItemValues === true
           || (activeItemValues && activeItemValues.indexOf(item.value) > -1))

--- a/src/toggle.component.ts
+++ b/src/toggle.component.ts
@@ -9,6 +9,7 @@ export interface Item {
   value?: any;
   text?: string;
   icon?: string;
+  data?: any;
 }
 @Component({
   selector: 'supre-toggle',


### PR DESCRIPTION
Allow custom data attributes for toggle buttons through a data property on items
`
[items]="[
{icon: 'u-supre-icon u-supre-icon--refresh-clear', value: 'clear', class: '-toggle-action', data : {'qa-id' : 'clear'}},
{icon: 'u-supre-icon u-supre-icon--filter', value: 'filter', class: '-toggle-action', data : {'qa-id' : 'filter'}},
{icon: 'u-supre-icon u-supre-icon--arrow-down-filled', value: 'dataGrid', class: '-toggle-action background open-bottom', data : {'qa-id' : 'open'}}
]
`
